### PR TITLE
chores - appmap, node, settings, example

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,9 @@
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {
 			"version": "1.6.1"
 		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "lts"
+		}
 	},
 	"customizations": {
 		"vscode": {
@@ -28,8 +31,5 @@
 			]
 		}
 	},
-
 	"postAttachCommand": "python3 -m venv venv && source venv/bin/activate && poetry install --with test,dev --no-interaction --no-root --sync"
-
 }
-

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# example@v0
+# DO NOT INCLUDE POSTGRES VALUES FOR CI
+# CI WILL USE THE POSTGRES INSTANCE PROVIDED BY THE GITHUB ACTIONS RUNNER
+POSTGRES_DB="tsdb"  # skip for CI
+POSTGRES_USER="username"  # skip for CI
+POSTGRES_PASSWORD="super-secret-password"  # skip for CI
+POSTGRES_PORT="5432"  # skip for CI
+POSTGRES_HOST="hostname.example.com"  # skip for CI
+TABLE_NAME="name of table containing data"
+BMW_USERNAME="email@example.com"
+BMW_PASSWORD="bmw-connected-drive-password"
+BMW_REGION="REST_OF_WORLD"
+BMW_VINS="comma,separated,list,of,vins"
+AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=storageaccountname;AccountKey=abcde/fghij==;BlobEndpoint=https://storageaccountname.blob.core.windows.net/;FileEndpoint=https://storageaccountname.file.core.windows.net/;QueueEndpoint=https://storageaccountname.queue.core.windows.net/;TableEndpoint=https://storageaccountname.table.core.windows.net/"

--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,7 @@ __azurite_db*__.json
 .flaskenv*
 !.env.project
 !.env.vault
-
+!.env.example
 
 # appmap
 /tmp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,13 +6,13 @@
   "azureFunctions.projectRuntime": "~4",
   "debug.internalConsoleOptions": "neverOpen",
   "python.defaultInterpreterPath": "${workspaceFolder}/venv/bin/python",
-  "python.linting.pylintEnabled": false,
-  "python.linting.flake8Enabled": true,
-  "python.linting.enabled": true,
-  "python.formatting.provider": "black",
   "python.testing.pytestArgs": [
     "test"
   ],
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true,
+  },
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "dotenv.enableAutocloaking": false,

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,24 +22,6 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "hypothesis (>=4.0)", "psutil (>=
 trio = ["trio (>=0.22)"]
 
 [[package]]
-name = "appmap"
-version = "1.17.1"
-description = "Create AppMap files by recording a Python application."
-optional = false
-python-versions = ">=3.7.2,<4.0.0"
-files = [
-    {file = "appmap-1.17.1-py3-none-any.whl", hash = "sha256:7595a5dd07ee2e8365e046eda2ed0c53efac6c33badec11c4b7311fa9a5b6066"},
-    {file = "appmap-1.17.1.tar.gz", hash = "sha256:7d27b856a3546a940798ce5729d11fe85235e63d6f89359517f34e44829418d6"},
-]
-
-[package.dependencies]
-importlib-metadata = ">=0.8"
-importlib-resources = ">=5.4.0,<6.0.0"
-inflection = ">=0.3.0"
-packaging = ">=19.0"
-PyYAML = ">=5.3.0"
-
-[[package]]
 name = "attrs"
 version = "23.1.0"
 description = "Classes Without Boilerplate"
@@ -619,54 +601,6 @@ python-versions = ">=3.5"
 files = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "6.8.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_metadata-6.8.0-py3-none-any.whl", hash = "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb"},
-    {file = "importlib_metadata-6.8.0.tar.gz", hash = "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"},
-]
-
-[package.dependencies]
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
-
-[[package]]
-name = "importlib-resources"
-version = "5.13.0"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-5.13.0-py3-none-any.whl", hash = "sha256:9f7bd0c97b79972a6cce36a366356d16d5e13b09679c11a58f1014bfdf8e64b2"},
-    {file = "importlib_resources-5.13.0.tar.gz", hash = "sha256:82d5c6cca930697dbbd86c93333bb2c2e72861d4789a11c2662b933e5ad2b528"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
-
-[[package]]
-name = "inflection"
-version = "0.5.1"
-description = "A port of Ruby on Rails inflector to Python"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
-    {file = "inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417"},
 ]
 
 [[package]]
@@ -1748,22 +1682,7 @@ files = [
 idna = ">=2.0"
 multidict = ">=4.0"
 
-[[package]]
-name = "zipp"
-version = "3.17.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
-    {file = "zipp-3.17.0.tar.gz", hash = "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
-
 [metadata]
 lock-version = "2.0"
 python-versions = ">3.9,<3.12"
-content-hash = "7b4e404bdcc837c351b89d1896ca55954482a24e2bd9daf8569c3ab63616c582"
+content-hash = "48fec346820ec37c5b2c29942d653dd4803f9c74041b379ea36802e0883b9f21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ pytest-mock = "^3.10.0"
 mock = "^5.0.1"
 jsonschema = "^4.17.3"
 pytest-asyncio = "^0.21.1"
-appmap = "^1.17.1"
 
 
 [build-system]


### PR DESCRIPTION
- add node to the devcontainer (so we can use npx with dotenv-vault)
- add an env.example file
- remove appmap
- remove some incorrect vscode workspace settings